### PR TITLE
VZ-9957 - safari doesn't support onclick events on select

### DIFF
--- a/lib/shared/addon/components/cluster-driver/driver-ociocne/component.js
+++ b/lib/shared/addon/components/cluster-driver/driver-ociocne/component.js
@@ -17,7 +17,6 @@ export default Component.extend(ClusterDriver, {
   configField:       'ociocneEngineConfig',
   step:              1,
   vcnCreationMode:   'Quick',
-  authRegionChoices: OCI_REGIONS,
   isNew:             equal('mode', 'new'),
   editing:           equal('mode', 'edit'),
 
@@ -251,6 +250,14 @@ export default Component.extend(ClusterDriver, {
   credentialObserver: observer('primaryResource.cloudCredentialId', function() {
     // when the credential changes, refresh the list of compartments
     this.get('fetchCompartmentsTask').perform();
+  }),
+  authRegionChoices: computed(() => {
+    return OCI_REGIONS.map((region) => {
+      return {
+        value: region,
+        label: region
+      }
+    });
   }),
   compartmentName: computed('flatCompartments', 'config.compartmentId', function() {
     const compartment = this.flatCompartments?.find((c) => c.id === this.config.compartmentId);

--- a/lib/shared/addon/components/cluster-driver/driver-ociocne/template.hbs
+++ b/lib/shared/addon/components/cluster-driver/driver-ociocne/template.hbs
@@ -31,11 +31,11 @@
           {{t 'clusterNew.ociocne.region.label'}}{{field-required}}
         </label>
         {{#if (and (eq step 1) isNew)}}
-          <select class="form-control" onchange={{action (mut config.region) value="target.value"}}>
-            {{#each authRegionChoices as |choice|}}
-              <option value={{choice}} selected={{eq config.region choice}}>{{choice}}</option>
-            {{/each}}
-          </select>
+          {{searchable-select class="form-control"
+                                  content=authRegionChoices
+                                  value=config.region
+
+          }}
           <p class="help-block">
             {{t 'clusterNew.ociocne.region.help'}}
           </p>
@@ -49,7 +49,10 @@
         </label>
         {{#input-or-display editable=(and (eq step 1) isNew) value=compartmentName}}
           {{#if this.fetchCompartmentsTask.isIdle}}
-            <select class="form-control" style="width: 40%" value={{config.compartmentId}} onclick="event.stopPropagation(); $('#compartmentTree').toggle();">
+            <div class="searchable-select show-dropdown-arrow">
+              <input readonly type="text" class="input-search" onclick="event.stopPropagation(); $('#compartmentTree').toggle();" value="{{ compartmentName }}"/>
+            </div>
+            <select hidden class="form-control" style="width: 40%" value={{config.compartmentId}}>
                       <option value="" hidden="true"></option>
                         {{#each [flatCompartments] as |choice|}}
                           <option value="{{choice.id}}" hidden="true">{{choice.name}}</option>
@@ -565,7 +568,10 @@
                         <table class="table fixed no-lines js-label-table">
                           <tbody>
                             <tr>
-                              <select class="form-control" value={{vcnCompartment}} onclick="event.stopPropagation(); $('#vcnCompartmentTree').toggle();">
+                              <div class="searchable-select show-dropdown-arrow">
+                                <input readonly type="text" class="input-search" onclick="event.stopPropagation(); $('#vcnCompartmentTree').toggle();" value="{{ vcnCompartmentName }}"/>
+                              </div>
+                              <select hidden class="form-control" value={{vcnCompartment}} onclick="javascript:event.stopPropagation(); $('#vcnCompartmentTree').toggle();">
                                 <option value="" hidden="true"></option>
                                   {{#each [flatCompartments] as |choice|}}
                                     <option value="{{choice.id}}" hidden="true">{{choice.name}}</option>


### PR DESCRIPTION
<!-- HTML Comments can be left in place or removed, dealers choice. They are present simply to guide you on your pull-request journey. --> 
Proposed changes
======
safari handling of onclick events inconsistent with chrome/ff. change compartment tree to use a fake dropdown based on searchable-select classes in stead of a select. also change region to use searchable-select for consistency across the row. fixes #VZ-9957

Types of changes
======
<!-- 

What types of changes does your code introduce to Rancher?
- Bugfix (non-breaking change which fixes an issue)
- New feature (non-breaking change which adds functionality)
- Breaking change (fix or feature that would cause existing functionality to not work as expected)

-->

Linked Issues
======
<!--

Link any related issues, pull-requests, or commit hashes that are relavent to this pull-request.

If you are opening a PR without a corresponding issue create an issue before you do. This will help QA massively. PR's opened without linked issues will not be merged until an issue is created and linked here. 

--> 

Further comments
======
<!-- 

If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc... 

-->
