### PR TITLE
OCNE UI fixes

### DIFF
--- a/lib/shared/addon/components/cluster-driver/driver-ociocne/component.js
+++ b/lib/shared/addon/components/cluster-driver/driver-ociocne/component.js
@@ -137,9 +137,6 @@ export default Component.extend(ClusterDriver, {
       set(this, 'step', 3);
       cb(true)
     },
-    isFlex(shape) {
-      return shape.includes('Flex')
-    },
     addNodePool() {
       const newName = `pool-${ this.newRandomizedName() }`
       let nodePools = get(this, 'nodePools')
@@ -150,9 +147,6 @@ export default Component.extend(ClusterDriver, {
         ocpus:      2,
         volumeSize: 100,
         shape:      'VM.Standard.E4.Flex',
-        isFlex() {
-          return this.shape.includes('Flex')
-        }
       }
 
       nodePools.pushObject(np)
@@ -515,16 +509,11 @@ export default Component.extend(ClusterDriver, {
   canCreateCluster: computed('config.{controlPlaneShape,imageDisplayName,nodeShape}', function() {
     return !(get(this, 'config.nodeShape') && get(this, 'config.controlPlaneShape') && get(this, 'config.imageDisplayName'));
   }),
-  isControlPlaneFlex: computed('config.controlPlaneShape', function() {
-    const shape = get(this, 'config.controlPlaneShape');
-
-    return shape && shape.includes('Flex');
-  }),
   // asynchronously fetch list of compartments from oci. Called anytime cloudCredentialId changes (via credentialObserver)
   fetchCompartmentsTask: task(function *() {
     const token = get(this, 'primaryResource.cloudCredentialId');
 
-    if (token && token !== null && token !== '') {
+    if (token && token !== '') {
       const auth = {
         type: 'cloud',
         token
@@ -742,5 +731,4 @@ export default Component.extend(ClusterDriver, {
 
     set(this, 'yamls', deserialized)
   }
-
 });

--- a/lib/shared/addon/components/cluster-driver/driver-ociocne/template.hbs
+++ b/lib/shared/addon/components/cluster-driver/driver-ociocne/template.hbs
@@ -30,7 +30,7 @@
         <label class="acc-label">
           {{t 'clusterNew.ociocne.region.label'}}{{field-required}}
         </label>
-        {{#if (and (eq step 1) isNew)}}
+        {{#if isNew}}
           {{searchable-select class="form-control"
                                   content=authRegionChoices
                                   value=config.region
@@ -47,7 +47,7 @@
         <label class="acc-label">
           {{t 'clusterNew.ociocne.compartment.label'}}{{field-required}}
         </label>
-        {{#input-or-display editable=(and (eq step 1) isNew) value=compartmentName}}
+        {{#input-or-display editable=isNew value=compartmentName}}
           {{#if this.fetchCompartmentsTask.isIdle}}
             <div class="searchable-select show-dropdown-arrow">
               <input readonly type="text" class="input-search" onclick="event.stopPropagation(); $('#compartmentTree').toggle();" value="{{ compartmentName }}"/>
@@ -279,7 +279,7 @@
           {{/input-or-display}}
         </div>
       </div>
-      {{#if isControlPlaneFlex }}
+      {{#if (is-flex config.controlPlaneShape)}}
         <div class="row pb-10">
           <div class="col span-4 mb-0">
             <label class="acc-label">
@@ -447,30 +447,32 @@
               {{/input-or-display}}
             </div>
           </div>
-          <div class="row">
-            <div class="col span-4 mb-0">
-              <label class="acc-label">
-                {{t 'clusterNew.ociocne.nodeOcpus.label'}}
-              </label>
-              {{#input-or-display editable=(eq step 2) value=np.ocpus}}
-                {{input-integer min=1 max=64 value=np.ocpus classNames="form-control" placeholder=(t 'clusterNew.ociocne.nodeOcpus.placeholder')}}
-                <p class="help-block">
-                  {{t 'clusterNew.ociocne.nodeOcpus.help'}}
-                </p>
-              {{/input-or-display}}
+          {{#if (is-flex np.shape)}}
+            <div class="row">
+              <div class="col span-4 mb-0">
+                <label class="acc-label">
+                  {{t 'clusterNew.ociocne.nodeOcpus.label'}}
+                </label>
+                {{#input-or-display editable=(eq step 2) value=np.ocpus}}
+                  {{input-integer min=1 max=64 value=np.ocpus classNames="form-control" placeholder=(t 'clusterNew.ociocne.nodeOcpus.placeholder')}}
+                  <p class="help-block">
+                    {{t 'clusterNew.ociocne.nodeOcpus.help'}}
+                  </p>
+                {{/input-or-display}}
+              </div>
+              <div class="col span-4 mb-0">
+                <label class="acc-label">
+                  {{t 'clusterNew.ociocne.nodeMemoryGbs.label'}}
+                </label>
+                {{#input-or-display editable=(eq step 2) value=np.memory}}
+                  {{input-integer min=2 max=1024 value=np.memory classNames="form-control" placeholder=(t 'clusterNew.ociocne.nodeMemoryGbs.placeholder')}}
+                  <p class="help-block">
+                    {{t 'clusterNew.ociocne.nodeMemoryGbs.help'}}
+                  </p>
+                {{/input-or-display}}
+              </div>
             </div>
-            <div class="col span-4 mb-0">
-              <label class="acc-label">
-                {{t 'clusterNew.ociocne.nodeMemoryGbs.label'}}
-              </label>
-              {{#input-or-display editable=(eq step 2) value=np.memory}}
-                {{input-integer min=2 max=1024 value=np.memory classNames="form-control" placeholder=(t 'clusterNew.ociocne.nodeMemoryGbs.placeholder')}}
-                <p class="help-block">
-                  {{t 'clusterNew.ociocne.nodeMemoryGbs.help'}}
-                </p>
-              {{/input-or-display}}
-            </div>
-          </div>
+          {{/if}}
           <div class="row">
             <div class="col span-2 mb-0">
               <button
@@ -680,7 +682,7 @@
               <div class="row">
                 <div class="col span-10">
                   <label class="acc-label">{{t 'clusterNew.ociocne.vcnCompartment.label'}}{{field-required}}</label>
-                  {{#input-or-display editable=(and (eq step 2) isNew) value=vcnCompartmentName}}
+                  {{#input-or-display editable=isNew value=vcnCompartmentName}}
                     {{#if this.fetchCompartmentsTask.isIdle}}
                       <div class="row">
                         <table class="table fixed no-lines js-label-table">
@@ -721,71 +723,55 @@
                     {{/if}}
                   {{/input-or-display}}
                 </div>
-                <div class="col span-4">
+                <div class="col span-10">
                   <label class="acc-label">
                     {{t 'clusterNew.ociocne.vcnId.label'}}{{field-required}}
                   </label>
-                  {{#if (eq step 2)}}
-                    {{#input-or-display value=config.vcnId}}
-                      {{searchable-select class="form-control"
-                                          content=vcnOptions
-                                          value=config.vcnId
-                      }}
-                    {{/input-or-display}}
-                  {{else}}
-                    <div>{{config.vcnId}}</div>
-                  {{/if}}
+                  {{#input-or-display value=config.vcnId}}
+                    {{searchable-select class="form-control"
+                                        content=vcnOptions
+                                        value=config.vcnId
+                    }}
+                  {{/input-or-display}}
                 </div>
               </div>
               <div class="row">
-                <div class="col span-4">
+                <div class="col span-10">
                   <label class="acc-label">
                     {{t 'clusterNew.ociocne.controlPlaneSubnet.label'}}{{field-required}}
                   </label>
-                  {{#if (eq step 2)}}
-                    {{#input-or-display value=config.controlPlaneSubnet}}
-                      {{searchable-select class="form-control"
-                                          content=subnetOptions
-                                          value=config.controlPlaneSubnet
-                      }}
-                    {{/input-or-display}}
-                  {{else}}
-                    <div>{{config.controlPlaneSubnet}}</div>
-                  {{/if}}
+                  {{#input-or-display value=config.controlPlaneSubnet}}
+                    {{searchable-select class="form-control"
+                                        content=subnetOptions
+                                        value=config.controlPlaneSubnet
+                    }}
+                  {{/input-or-display}}
                 </div>
               </div>
               <div class="row">
-                <div class="col span-4">
+                <div class="col span-10">
                   <label class="acc-label">
                     {{t 'clusterNew.ociocne.loadBalancerSubnet.label'}}{{field-required}}
                   </label>
-                  {{#if (eq step 2)}}
-                    {{#input-or-display value=config.loadBalancerSubnet}}
-                      {{searchable-select class="form-control"
-                                          content=subnetOptions
-                                          value=config.loadBalancerSubnet
-                      }}
-                    {{/input-or-display}}
-                  {{else}}
-                    <div>{{config.loadBalancerSubnet}}</div>
-                  {{/if}}
+                  {{#input-or-display value=config.loadBalancerSubnet}}
+                    {{searchable-select class="form-control"
+                                        content=subnetOptions
+                                        value=config.loadBalancerSubnet
+                    }}
+                  {{/input-or-display}}
                 </div>
               </div>
               <div class="row">
-                <div class="col span-4">
+                <div class="col span-10">
                   <label class="acc-label">
                     {{t 'clusterNew.ociocne.workerNodeSubnet.label'}}{{field-required}}
                   </label>
-                  {{#if (eq step 2)}}
-                    {{#input-or-display value=config.workerNodeSubnet}}
-                      {{searchable-select class="form-control"
-                                          content=subnetOptions
-                                          value=config.workerNodeSubnet
-                      }}
-                    {{/input-or-display}}
-                  {{else}}
-                    <div>{{config.workerNodeSubnet}}</div>
-                  {{/if}}
+                  {{#input-or-display value=config.workerNodeSubnet}}
+                    {{searchable-select class="form-control"
+                                        content=subnetOptions
+                                        value=config.workerNodeSubnet
+                    }}
+                  {{/input-or-display}}
                 </div>
               </div>
             {{/if}}
@@ -943,7 +929,7 @@
             {{/input-or-display}}
           </div>
         </div>
-        {{#if isControlPlaneFlex }}
+        {{#if (is-flex config.controlPlaneShape)}}
           <div class="row pb-10">
             <div class="col span-4 mb-0">
               <label class="acc-label">
@@ -1112,31 +1098,32 @@
                 {{/input-or-display}}
               </div>
             </div>
-            <div class="row">
-              <div class="col span-4 mb-0">
-                <label class="acc-label">
-                  {{t 'clusterNew.ociocne.nodeOcpus.label'}}
-                </label>
-                {{#input-or-display editable=(and (eq step 3) isNew) value=np.ocpus}}
-                  {{input-integer min=1 max=64 value=np.ocpus classNames="form-control" placeholder=(t 'clusterNew.ociocne.nodeOcpus.placeholder')}}
-                  <p class="help-block">
-                    {{t 'clusterNew.ociocne.nodeOcpus.help'}}
-                  </p>
-                {{/input-or-display}}
+            {{#if (is-flex np.shape)}}
+              <div class="row">
+                <div class="col span-4 mb-0">
+                  <label class="acc-label">
+                    {{t 'clusterNew.ociocne.nodeOcpus.label'}}
+                  </label>
+                  {{#input-or-display editable=(and (eq step 3) isNew) value=np.ocpus}}
+                    {{input-integer min=1 max=64 value=np.ocpus classNames="form-control" placeholder=(t 'clusterNew.ociocne.nodeOcpus.placeholder')}}
+                    <p class="help-block">
+                      {{t 'clusterNew.ociocne.nodeOcpus.help'}}
+                    </p>
+                  {{/input-or-display}}
+                </div>
+                <div class="col span-4 mb-0">
+                  <label class="acc-label">
+                    {{t 'clusterNew.ociocne.nodeMemoryGbs.label'}}
+                  </label>
+                  {{#input-or-display editable=(and (eq step 3) isNew) value=np.memory}}
+                    {{input-integer min=2 max=1024 value=np.memory classNames="form-control" placeholder=(t 'clusterNew.ociocne.nodeMemoryGbs.placeholder')}}
+                    <p class="help-block">
+                      {{t 'clusterNew.ociocne.nodeMemoryGbs.help'}}
+                    </p>
+                  {{/input-or-display}}
+                </div>
               </div>
-              <div class="col span-4 mb-0">
-                <label class="acc-label">
-                  {{t 'clusterNew.ociocne.nodeMemoryGbs.label'}}
-                </label>
-                {{#input-or-display editable=(and (eq step 3) isNew) value=np.memory}}
-                  {{input-integer min=2 max=1024 value=np.memory classNames="form-control" placeholder=(t 'clusterNew.ociocne.nodeMemoryGbs.placeholder')}}
-                  <p class="help-block">
-                    {{t 'clusterNew.ociocne.nodeMemoryGbs.help'}}
-                  </p>
-                {{/input-or-display}}
-              </div>
-            </div>
-
+            {{/if}}
             <div class="row">
               <div class="col span-2 mb-0">
                 <button

--- a/lib/shared/addon/helpers/is-flex.js
+++ b/lib/shared/addon/helpers/is-flex.js
@@ -1,0 +1,7 @@
+import { helper } from '@ember/component/helper';
+
+export function isFlex(params) {
+  return params[0].includes('Flex')
+}
+
+export default helper(isFlex);

--- a/lib/shared/app/helpers/is-flex.js
+++ b/lib/shared/app/helpers/is-flex.js
@@ -1,0 +1,1 @@
+export { default, isFlex } from 'shared/helpers/is-flex';

--- a/translations/en-us.yaml
+++ b/translations/en-us.yaml
@@ -4388,8 +4388,8 @@ clusterNew:
       title: Advanced Settings
       detail: Advanced Cluster Configuration
     access:
-      next: "Authenticate and Configure Cluster"
-      loading: Loading values from Oracle Cloud Infrastructure
+      next: "Next"
+      loading: Loading...
       title: Choose the region and credentials that will be used for Oracle Cloud authentication.
       detail: Choose the region and credentials that will be used for Oracle Cloud authentication.
     cloudCredentialId:
@@ -4537,8 +4537,8 @@ clusterNew:
       title: Network Setup
       detail: Configure the virtual cloud network that will be used for your Kubernetes cluster.
       detailEdit: Virtual Cloud network and subnets used for your Kubernetes cluster.
-      next: Configure Control plane and worker nodes
-      loading: Loading node configuration
+      next: Next
+      loading: Loading...
       quick: Quick Create
       quickHelp: Create a default VCN infrastructure for your cluster
       quickResources:


### PR DESCRIPTION
- only show worker node CPU/Memory if the node shape is a "Flex" shape.
- expand vcn subnet combo box width.
- allow region, compartment, and vcn information to be editable after moving to the next section.
- rename "next" button text to just say "Next" and "Loading..." instead of the previous, verbose text.